### PR TITLE
Naive algorithm 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+assert_approx_eq = "1.1.0"
 midly = "0.5"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Status and roadmap
 
 - [x] choose MIDI parser library
 - [x] ensure we can get data from MIDI files using the chosen MIDI parser (midly)
+- [x] data type for an in-memory reference score (milliseconds and pitches)
+- [ ] first naïve stateless score follower algorithm `selim-0.1.0`
+  - [ ] inputs:
+    - [ ] complete reference score (ms+pitch)
+    - [ ] complete live input so far (ms+pitch)
+    - [ ] position of last matching previous input note in the score
+    - [ ] position of last matching previous input note in the live input
+    - [ ] position of first new note in the live input
+    - [ ] time warp factor at matching note
+  - [ ] outputs:
+    - [ ] reference time index at last new input note (ms)
+    - [ ] time warp factor at last new matching note
+    - [ ] list of ignored new input notes (ms+pitch)
+  - [ ] support only monophony (order of events matters)
+  - [ ] ignore unexpected (wrong/extra) notes
+  - [ ] keep waiting for next correct note
+- [ ] unit tests for `selim-0.1.0`
 - [ ] function to turn a MIDI file into an in-memory reference score (ms+pitch)
   - [ ] use only the first track which contains meaningful MIDI data
   - [ ] use only the first channel which contains meaningful MIDI data
@@ -53,21 +70,6 @@ Status and roadmap
   - [ ] ignore velocity
   - [ ] convert time offsets to milliseconds (disregarding tempo for now)
   - [ ] tool to output reference score on stdout
-- [ ] first naïve stateless score follower algorithm `selim-0.1.0`
-  - [ ] inputs:
-    - [ ] complete reference score (ms+pitch)
-    - [ ] reference time index at last previous input note (ms)
-    - [ ] reference time warp factor at last previous input note
-    - [ ] previous input notes (ms+pitch)
-    - [ ] new input notes (ms+pitch)
-  - [ ] outputs:
-    - [ ] reference time index at last new input note (ms)
-    - [ ] reference time warp factor at last new input note
-    - [ ] list of ignored new input notes (ms+pitch)
-  - [ ] support only monophony (order of events matters)
-  - [ ] ignore unexpected (wrong/extra) notes
-  - [ ] keep waiting for next correct note
-- [ ] unit tests for `selim-0.1.0`
 - [ ] choose MIDI input library
 - [ ] real-time tool to convert MIDI input into ms+pitch events on stdout
 - [ ] real-time tool to test out `selim-0.1.x`

--- a/README.md
+++ b/README.md
@@ -48,20 +48,20 @@ Status and roadmap
 - [x] ensure we can get data from MIDI files using the chosen MIDI parser (midly)
 - [x] data type for an in-memory reference score (milliseconds and pitches)
 - [ ] first naïve stateless score follower algorithm `selim-0.1.0`
-  - [ ] inputs:
-    - [ ] complete reference score (ms+pitch)
-    - [ ] complete live input so far (ms+pitch)
-    - [ ] position of last matching previous input note in the score
-    - [ ] position of last matching previous input note in the live input
-    - [ ] position of first new note in the live input
-    - [ ] time warp factor at matching note
+  - [x] inputs:
+    - [x] complete reference score (ms+pitch)
+    - [x] complete live input so far (ms+pitch)
+    - [x] position of last matching previous input note in the score
+    - [x] position of last matching previous input note in the live input
+    - [x] position of first new note in the live input
+    - [x] time stretch factor at last matching note
   - [ ] outputs:
-    - [ ] reference time index at last new input note (ms)
-    - [ ] time warp factor at last new matching note
-    - [ ] list of ignored new input notes (ms+pitch)
-  - [ ] support only monophony (order of events matters)
-  - [ ] ignore unexpected (wrong/extra) notes
-  - [ ] keep waiting for next correct note
+    - [x] reference time index at last new input note (ms)
+    - [ ] time stretch factor at last new matching note
+    - [x] list of ignored new input notes (ms+pitch)
+  - [x] support only monophony (order of events matters)
+  - [x] ignore unexpected (wrong/extra) notes
+  - [x] keep waiting for next correct note
 - [ ] unit tests for `selim-0.1.0`
 - [ ] function to turn a MIDI file into an in-memory reference score (ms+pitch)
   - [ ] use only the first track which contains meaningful MIDI data
@@ -78,12 +78,12 @@ Status and roadmap
     - [ ] real-time ms+pitch events on stdin
   - [ ] outputs on stdout:
     - [ ] reference time index at last new input note (ms)
-    - [ ] reference time warp factor at last new input note
+    - [ ] reference time stretch factor at last new input note
     - [ ] ignored input notes
 - [ ] wrong/missed/extra note tolerant score follower algorithm `selim-0.1.1`
   - [ ] match new input notes with future reference notes within a time window
   - [ ] jump directly to first matching note
-- [ ] time warp factor adjustment limit in `selim-0.1.2`
+- [ ] time stretch factor adjustment limit in `selim-0.1.2`
 - [ ] refine MIDI file interpretation (ms+pitch+vel+dur)
   - [ ] take tempo changes into account when converting to milliseconds
   - [ ] include velocity

--- a/src/bin/selim-mid-info.rs
+++ b/src/bin/selim-mid-info.rs
@@ -1,5 +1,5 @@
+use midly::{MidiMessage::NoteOn, TrackEventKind::Midi};
 use std::env;
-use midly::{TrackEvent, TrackEventKind::Midi, MidiMessage::NoteOn};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -17,17 +17,17 @@ fn main() {
     let track = &smf.tracks[0];
     println!("first track has {} events!", track.len());
 
-    let musical_events: Vec<&TrackEvent> = track
-        .into_iter()
-        .filter(|event| match event.kind {
-            Midi {
-                channel,
-                message: NoteOn{key: _, vel: _},
-            } => channel == 1,
-            _ => false,
-        })
-        .collect();
-    println!("first track has {} 'note on' events on channel 1!", musical_events.len());
+    let musical_events = track.iter().filter(|event| match event.kind {
+        Midi {
+            channel,
+            message: NoteOn { key: _, vel: _ },
+        } => channel == 1,
+        _ => false,
+    });
+    println!(
+        "first track has {} 'note on' events on channel 1!",
+        musical_events.count()
+    );
 
     // Modify the file
     smf.header.format = midly::Format::Sequential;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,194 @@
+/// A note with a given pitch at a given timestamp in a score or in a live performance
+#[derive(Clone, Copy)]
+pub struct ScoreNote {
+    time: u32,
+    pitch: u8,
+}
+
+/// Matches incoming notes with next notes in the score.
+/// This is a super naïve algorithm which
+/// * supports only monophony (order of events matters),
+/// * ignores unexpected (wrong/extra) notes, and
+/// * keeps waiting for the next correct note.
+///
+/// # Example
+///
+/// |                        111
+/// |        time: 0123456789012
+/// |                  v------------ prev_match_score_index == 1 (last matched note)
+/// | score index: 0   1 2 3 4 5
+/// |       score: C   D E F G A  // expected notes
+/// |  live notes:   C D   E   F  // actual played notes
+/// |  live index:   0 1   2   3
+/// |                  ^   ^   ^----
+/// |                  |   `-------- new_live_index == 2 (first newly received note)
+/// |                  `------------ prev_match_live_index == 1 (last matched node)
+///
+/// This would return
+/// * 8 as the timestamp of the score since that's when the last live note (F) occurs in
+///   the score
+/// * 2.0 as the time stretch factor since E..F took two time steps in the score but
+///   four time steps in the live performance
+/// * an empty vector of ignored notes
+///                          
+/// # Arguments
+///
+/// * score - The complete expected musical score with timestamps and pitches
+/// * live - The live performance recorded so far, with timestamps and pitches
+/// * prev_match_score_index - For the last previously matched note between the live
+///                            performance and the expected score, this gives the index
+///                            of the event in the expected score
+/// * prev_match_live_index - For the last previously matched note, this gives the index
+///                           of the event in the live performance
+/// * new_live_index - Index of the first new note received for the live performance
+///                    since the previous call to this function
+/// * last_stretch_factor - The time stretch factor returned by the previous call to
+///                         this function
+///
+/// # Return value
+///
+/// A 3-tuple of
+/// * the timestamp of the score at the last new input note
+/// * the time stretch factor at the last new matching input note
+/// * the index of the last matched note in the score
+/// * the index of the last matched note in the live performance
+/// * ignored new input notes as a list of live performance indices
+pub fn follow_score(
+    score: Vec<ScoreNote>,
+    live: Vec<ScoreNote>,
+    prev_match_score_index: Option<usize>,
+    prev_match_live_index: Option<usize>,
+    new_live_index: usize,
+    last_stretch_factor: f32,
+) -> (u32, f32, Option<usize>, Option<usize>, Vec<usize>) {
+    let mut score_index = match prev_match_score_index {
+        None => 0,        // start from beginning of score if nothing matched yet
+        Some(i) => i + 1, // continue in the score just after last previous match
+    };
+    let (mut next_match_score_index, mut next_match_live_index) = (None, None);
+    let mut ignored: Vec<usize> = vec![];
+    for live_index in new_live_index..live.len() {
+        let live_note = live[live_index];
+        let matching_index = score[score_index..]
+            .iter()
+            .position(|score_note| score_note.pitch == live_note.pitch);
+        match matching_index {
+            Some(i) => {
+                next_match_live_index = Some(live_index);
+                score_index += i;
+                next_match_score_index = Some(score_index);
+                score_index += 1;
+            }
+            None => ignored.push(live_index),
+        };
+    }
+    let (next_stretch_factor, next_time, prev_match_score_index_, prev_match_live_index_);
+    match (
+        prev_match_score_index,
+        prev_match_live_index,
+        next_match_score_index,
+        next_match_live_index,
+    ) {
+        (Some(score_old), Some(live_old), Some(score_new), Some(live_new)) => {
+            let elapsed_ref = score[score_new].time - score[score_old].time;
+            let elapsed_live = live[live_new].time - live[live_old].time;
+            next_stretch_factor = (elapsed_live as f32) / (elapsed_ref as f32);
+            prev_match_score_index_ = score_old;
+            prev_match_live_index_ = live_old;
+        }
+        _ => {
+            next_stretch_factor = last_stretch_factor;
+            prev_match_score_index_ = prev_match_score_index.unwrap_or(0);
+            prev_match_live_index_ = prev_match_live_index.unwrap_or(0);
+        }
+    };
+    let prev_match_score_time = score[prev_match_score_index_].time;
+    let live_end_time = live[live.len() - 1].time;
+    let prev_match_live_time = live[prev_match_live_index_].time;
+    next_time = prev_match_score_time
+        + ((live_end_time - prev_match_live_time) as f32 / next_stretch_factor) as u32;
+    (
+        next_time,
+        next_stretch_factor,
+        next_match_score_index,
+        next_match_live_index,
+        ignored,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! note {
+        ( $t:expr, $p:expr ) => {
+            ScoreNote {
+                time: $t,
+                pitch: $p,
+            }
+        };
+    }
+
+    const TEST_SCORE: [ScoreNote; 3] = [note!(1000, 60), note!(1100, 62), note!(1200, 64)];
+
+    #[test]
+    fn match_the_only_note() {
+        let score = [note!(1000, 60)];
+        let live = [note!(5, 60)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(score.to_vec(), live.to_vec(), None, None, 0, 1.0);
+        assert_eq!(time, 1000);
+        assert_eq!(stretch_factor, 1.0);
+        assert_eq!(last_match_score, Some(0));
+        assert_eq!(last_match_live, Some(0));
+        assert_eq!(ignored.is_empty(), true);
+    }
+
+    #[test]
+    fn match_first() {
+        let live = [note!(5, 60)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(TEST_SCORE.to_vec(), live.to_vec(), None, None, 0, 1.0);
+        assert_eq!(time, 1000);
+        assert_eq!(stretch_factor, 1.0);
+        assert_eq!(last_match_score, Some(0));
+        assert_eq!(last_match_live, Some(0));
+        assert_eq!(ignored.is_empty(), true);
+    }
+
+    #[test]
+    fn match_second() {
+        let live = [note!(5, 60), note!(55, 62)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+        assert_eq!(time, 1100);
+        assert_eq!(stretch_factor, 0.5);
+        assert_eq!(last_match_score, Some(1));
+        assert_eq!(last_match_live, Some(1));
+        assert_eq!(ignored.is_empty(), true);
+    }
+
+    #[test]
+    fn skip_extra_note() {
+        let live = [note!(5, 60), note!(25, 61), note!(55, 62)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+        assert_eq!(time, 1100);
+        assert_eq!(stretch_factor, 0.5);
+        assert_eq!(last_match_score, Some(1));
+        assert_eq!(last_match_live, Some(2));
+        assert_eq!(ignored, vec![1]);
+    }
+
+    #[test]
+    fn skip_missing_note() {
+        let live = [note!(5, 60), note!(55, 64)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+        assert_eq!(time, 1200);
+        assert_eq!(stretch_factor, 0.25);
+        assert_eq!(last_match_score, Some(2));
+        assert_eq!(last_match_live, Some(1));
+        assert_eq!(ignored.is_empty(), true);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ pub struct ScoreNote {
 }
 
 fn find_next_match_after(score: &Vec<ScoreNote>, score_index: usize, pitch: u8) -> Option<usize> {
-    let matching_index = score[score_index..]
+    match score[score_index..]
         .iter()
-        .position(|score_note| score_note.pitch == pitch);
-    match matching_index {
+        .position(|score_note| score_note.pitch == pitch)
+    {
         Some(i) => Some(score_index + i),
         None => None,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 /// A note with a given pitch at a given timestamp in a score or in a live performance
 #[derive(Clone, Copy)]
 pub struct ScoreNote {
@@ -5,18 +7,15 @@ pub struct ScoreNote {
     pitch: u8,
 }
 
-fn find_next_match_after(score: &Vec<ScoreNote>, score_index: usize, pitch: u8) -> Option<usize> {
-    match score[score_index..]
+fn find_next_match_after(score: &[ScoreNote], score_index: usize, pitch: u8) -> Option<usize> {
+    score[score_index..]
         .iter()
         .position(|score_note| score_note.pitch == pitch)
-    {
-        Some(i) => Some(score_index + i),
-        None => None,
-    }
+        .map(|i| score_index + i)
 }
 
 fn time_difference(
-    score: &Vec<ScoreNote>,
+    score: &[ScoreNote],
     index1: Option<usize>,
     index2: Option<usize>,
 ) -> Option<u32> {
@@ -27,8 +26,8 @@ fn time_difference(
 }
 
 fn find_newest_match(
-    score: &Vec<ScoreNote>,
-    live: &Vec<ScoreNote>,
+    score: &[ScoreNote],
+    live: &[ScoreNote],
     prev_match_score_index: Option<usize>,
     new_live_index: usize,
 ) -> (Option<usize>, Option<usize>, Vec<usize>) {
@@ -39,7 +38,7 @@ fn find_newest_match(
     let (mut next_match_score_index, mut next_match_live_index) = (None, None);
     let mut ignored: Vec<usize> = vec![];
     for (live_index, live_note) in live.iter().enumerate().skip(new_live_index) {
-        let matching_index = find_next_match_after(&score, score_index, live_note.pitch);
+        let matching_index = find_next_match_after(score, score_index, live_note.pitch);
         match matching_index {
             Some(i) => {
                 next_match_live_index = Some(live_index);
@@ -65,12 +64,12 @@ fn get_stretch_factor(
 
 /// Returns the score time in milliseconds corresponding to the latest live note
 /// (whether matched or unmatched)
-/// 
+///
 /// Corrects the elapsed time since the last match using the calculated stretch factor,
 /// and adds that to the score time of the last match.
 fn get_score_time(
-    score: &Vec<ScoreNote>,
-    live: &Vec<ScoreNote>,
+    score: &[ScoreNote],
+    live: &[ScoreNote],
     prev_score_index: Option<usize>,
     prev_live_index: Option<usize>,
     stretch_factor: f32,
@@ -183,7 +182,7 @@ mod tests {
         assert_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
         assert_eq!(last_match_live, Some(0));
-        assert_eq!(ignored.is_empty(), true);
+        assert!(ignored.is_empty());
     }
 
     #[test]
@@ -195,7 +194,7 @@ mod tests {
         assert_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
         assert_eq!(last_match_live, Some(0));
-        assert_eq!(ignored.is_empty(), true);
+        assert!(ignored.is_empty());
     }
 
     #[test]
@@ -207,7 +206,7 @@ mod tests {
         assert_eq!(stretch_factor, 0.5);
         assert_eq!(last_match_score, Some(1));
         assert_eq!(last_match_live, Some(1));
-        assert_eq!(ignored.is_empty(), true);
+        assert!(ignored.is_empty());
     }
 
     #[test]
@@ -231,6 +230,6 @@ mod tests {
         assert_eq!(stretch_factor, 0.25);
         assert_eq!(last_match_score, Some(2));
         assert_eq!(last_match_live, Some(1));
-        assert_eq!(ignored.is_empty(), true);
+        assert!(ignored.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,21 +63,22 @@ fn get_stretch_factor(
     }
 }
 
-fn get_next_time(
+/// Returns the score time in milliseconds corresponding to the latest live note
+/// (whether matched or unmatched)
+/// 
+/// Corrects the elapsed time since the last match using the calculated stretch factor,
+/// and adds that to the score time of the last match.
+fn get_score_time(
     score: &Vec<ScoreNote>,
     live: &Vec<ScoreNote>,
-    prev_match_score_index: Option<usize>,
-    prev_match_live_index: Option<usize>,
+    prev_score_index: Option<usize>,
+    prev_live_index: Option<usize>,
     stretch_factor: f32,
 ) -> u32 {
-    let prev_match_score_time = score[prev_match_score_index.unwrap_or(0)].time;
-    let elapsed_live = time_difference(
-        live,
-        prev_match_live_index.or(Some(0)),
-        Some(live.len() - 1),
-    )
-    .unwrap() as f32;
-    prev_match_score_time + (elapsed_live / stretch_factor) as u32
+    let prev_score_time = score[prev_score_index.unwrap_or(0)].time;
+    let elapsed_live =
+        time_difference(live, prev_live_index.or(Some(0)), Some(live.len() - 1)).unwrap();
+    prev_score_time + (elapsed_live as f32 / stretch_factor) as u32
 }
 
 /// Matches incoming notes with next notes in the score.
@@ -141,7 +142,7 @@ pub fn follow_score(
     let elapsed_score = time_difference(&score, prev_match_score_index, next_match_score_index);
     let elapsed_live = time_difference(&live, prev_match_live_index, next_match_live_index);
     let stretch_factor = get_stretch_factor(elapsed_score, elapsed_live, prev_stretch_factor);
-    let score_time = get_next_time(
+    let score_time = get_score_time(
         &score,
         &live,
         prev_match_score_index,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
-#![warn(clippy::all)]
+use crate::score::ScoreNote;
 
-/// A note with a given pitch at a given timestamp in a score or in a live performance
-#[derive(Clone, Copy)]
-pub struct ScoreNote {
-    time: u32,
-    pitch: u8,
-}
+#[macro_use]
+mod score;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Match {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,21 +162,20 @@ mod tests {
     use super::*;
     use assert_approx_eq::assert_approx_eq;
 
-    macro_rules! note {
-        ( $t:expr, $p:expr ) => {
-            ScoreNote {
-                time: $t,
-                pitch: $p,
-            }
-        };
+    macro_rules! notes {
+        (
+            $( ($t: expr, $p: expr) ),+
+        ) => {
+            [ $( ScoreNote {time: $t, pitch: $p} ),+ ]
+        }
     }
 
-    const TEST_SCORE: [ScoreNote; 3] = [note!(1000, 60), note!(1100, 62), note!(1200, 64)];
+    const TEST_SCORE: [ScoreNote; 3] = notes![(1000, 60), (1100, 62), (1200, 64)];
 
     #[test]
     fn match_the_only_note() {
-        let score = [note!(1000, 60)];
-        let live = [note!(5, 60)];
+        let score = notes![(1000, 60)];
+        let live = notes![(5, 60)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(&score, &live, None, None, 0, 1.0);
         assert_eq!(time, 1000);
@@ -188,7 +187,7 @@ mod tests {
 
     #[test]
     fn match_first() {
-        let live = [note!(5, 60)];
+        let live = notes![(5, 60)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(&TEST_SCORE, &live, None, None, 0, 1.0);
         assert_eq!(time, 1000);
@@ -200,7 +199,7 @@ mod tests {
 
     #[test]
     fn match_second() {
-        let live = [note!(5, 60), note!(55, 62)];
+        let live = notes![(5, 60), (55, 62)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
@@ -212,7 +211,7 @@ mod tests {
 
     #[test]
     fn skip_extra_note() {
-        let live = [note!(5, 60), note!(25, 61), note!(55, 62)];
+        let live = notes![(5, 60), (25, 61), (55, 62)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
@@ -224,7 +223,7 @@ mod tests {
 
     #[test]
     fn skip_missing_note() {
-        let live = [note!(5, 60), note!(55, 64)];
+        let live = notes![(5, 60), (55, 64)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1200);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ pub fn follow_score(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_approx_eq::assert_approx_eq;
 
     macro_rules! note {
         ( $t:expr, $p:expr ) => {
@@ -179,7 +180,7 @@ mod tests {
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(score.to_vec(), live.to_vec(), None, None, 0, 1.0);
         assert_eq!(time, 1000);
-        assert_eq!(stretch_factor, 1.0);
+        assert_approx_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
         assert_eq!(last_match_live, Some(0));
         assert!(ignored.is_empty());
@@ -191,7 +192,7 @@ mod tests {
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(TEST_SCORE.to_vec(), live.to_vec(), None, None, 0, 1.0);
         assert_eq!(time, 1000);
-        assert_eq!(stretch_factor, 1.0);
+        assert_approx_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
         assert_eq!(last_match_live, Some(0));
         assert!(ignored.is_empty());
@@ -203,7 +204,7 @@ mod tests {
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
-        assert_eq!(stretch_factor, 0.5);
+        assert_approx_eq!(stretch_factor, 0.5);
         assert_eq!(last_match_score, Some(1));
         assert_eq!(last_match_live, Some(1));
         assert!(ignored.is_empty());
@@ -215,7 +216,7 @@ mod tests {
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
-        assert_eq!(stretch_factor, 0.5);
+        assert_approx_eq!(stretch_factor, 0.5);
         assert_eq!(last_match_score, Some(1));
         assert_eq!(last_match_live, Some(2));
         assert_eq!(ignored, vec![1]);
@@ -227,7 +228,7 @@ mod tests {
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
             follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1200);
-        assert_eq!(stretch_factor, 0.25);
+        assert_approx_eq!(stretch_factor, 0.25);
         assert_eq!(last_match_score, Some(2));
         assert_eq!(last_match_live, Some(1));
         assert!(ignored.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,4 +232,16 @@ mod tests {
         assert_eq!(last_match_live, Some(1));
         assert!(ignored.is_empty());
     }
+
+    #[test]
+    fn only_wrong_notes() {
+        let live = notes![(5, 60), (55, 63), (105, 66)];
+        let (time, stretch_factor, last_match_score, last_match_live, ignored) =
+            follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
+        assert_eq!(time, 1100);
+        assert_approx_eq!(stretch_factor, 1.0);
+        assert_eq!(last_match_score, None);
+        assert_eq!(last_match_live, None);
+        assert_eq!(ignored, vec![1, 2]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,24 +99,16 @@ pub fn follow_score(
             None => ignored.push(live_index),
         };
     }
-    let (next_stretch_factor, prev_match_score_index_, prev_match_live_index_);
-    let elapsed_ref = time_difference(&score, prev_match_score_index, next_match_score_index);
+
+    let elapsed_score = time_difference(&score, prev_match_score_index, next_match_score_index);
     let elapsed_live = time_difference(&live, prev_match_live_index, next_match_live_index);
-    match (elapsed_ref, elapsed_live) {
-        (Some(e_score), Some(e_live)) => {
-            next_stretch_factor = (e_live as f32) / (e_score as f32);
-            prev_match_score_index_ = prev_match_score_index.unwrap();
-            prev_match_live_index_ = prev_match_live_index.unwrap();
-        }
-        _ => {
-            next_stretch_factor = last_stretch_factor;
-            prev_match_score_index_ = prev_match_score_index.unwrap_or(0);
-            prev_match_live_index_ = prev_match_live_index.unwrap_or(0);
-        }
+    let next_stretch_factor = match (elapsed_score, elapsed_live) {
+        (Some(e_score), Some(e_live)) => (e_live as f32) / (e_score as f32),
+        _ => last_stretch_factor,
     };
-    let prev_match_score_time = score[prev_match_score_index_].time;
+    let prev_match_score_time = score[prev_match_score_index.unwrap_or(0)].time;
     let live_end_time = live[live.len() - 1].time;
-    let prev_match_live_time = live[prev_match_live_index_].time;
+    let prev_match_live_time = live[prev_match_live_index.unwrap_or(0)].time;
     let next_time = prev_match_score_time
         + ((live_end_time - prev_match_live_time) as f32 / next_stretch_factor) as u32;
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,11 @@ pub struct ScoreNote {
     pitch: u8,
 }
 
+pub struct Match {
+    score_index: usize,
+    live_index: usize,
+}
+
 fn find_next_match_after(score: &[ScoreNote], score_index: usize, pitch: u8) -> Option<usize> {
     score[score_index..]
         .iter()
@@ -25,30 +30,29 @@ fn time_difference(
     }
 }
 
-fn find_newest_match(
+fn find_new_matches(
     score: &[ScoreNote],
     live: &[ScoreNote],
     prev_match_score_index: Option<usize>,
     new_live_index: usize,
-) -> (Option<usize>, Option<usize>, Vec<usize>) {
-    let mut score_index = match prev_match_score_index {
+) -> (Vec<Match>, Vec<usize>) {
+    let mut score_pointer = match prev_match_score_index {
         None => 0,        // start from beginning of score if nothing matched yet
         Some(i) => i + 1, // continue in the score just after last previous match
     };
-    let (mut next_match_score_index, mut next_match_live_index) = (None, None);
+    let mut matches: Vec<Match> = vec![];
     let mut ignored: Vec<usize> = vec![];
     for (live_index, live_note) in live.iter().enumerate().skip(new_live_index) {
-        let matching_index = find_next_match_after(score, score_index, live_note.pitch);
+        let matching_index = find_next_match_after(score, score_pointer, live_note.pitch);
         match matching_index {
-            Some(i) => {
-                next_match_live_index = Some(live_index);
-                next_match_score_index = Some(i);
-                score_index = i + 1;
+            Some(score_index) => {
+                matches.push(Match { score_index, live_index });
+                score_pointer = score_index + 1;
             }
             None => ignored.push(live_index),
         };
     }
-    (next_match_score_index, next_match_live_index, ignored)
+    (matches, ignored)
 }
 
 fn get_stretch_factor(
@@ -136,8 +140,8 @@ pub fn follow_score(
     new_live_index: usize,
     prev_stretch_factor: f32,
 ) -> (u32, f32, Option<usize>, Option<usize>, Vec<usize>) {
-    let (next_match_score_index, next_match_live_index, ignored) =
-        find_newest_match(score, live, prev_match_score_index, new_live_index);
+    let (new_matches, ignored) =
+        find_new_matches(score, live, prev_match_score_index, new_live_index);
     let elapsed_score = time_difference(score, prev_match_score_index, next_match_score_index);
     let elapsed_live = time_difference(live, prev_match_live_index, next_match_live_index);
     let stretch_factor = get_stretch_factor(elapsed_score, elapsed_live, prev_stretch_factor);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,21 +13,44 @@ pub struct Match {
     live_index: usize,
 }
 
-fn find_next_match_after(score: &[ScoreNote], score_index: usize, pitch: u8) -> Option<usize> {
-    score[score_index..]
-        .iter()
-        .position(|score_note| score_note.pitch == pitch)
-        .map(|i| score_index + i)
+impl Match {
+    pub fn new(score_index: usize, live_index: usize) -> Self {
+        Self {
+            score_index,
+            live_index,
+        }
+    }
 }
 
-fn time_difference(
-    score: &[ScoreNote],
-    index1: usize,
-    index2: usize,
-) -> u32 {
+/// Finds the next note with given `pitch`, starting from `score[index]`
+fn find_next_match_starting_at(score: &[ScoreNote], index: usize, pitch: u8) -> Option<usize> {
+    score[index..]
+        .iter()
+        .position(|note| note.pitch == pitch)
+        .map(|i| index + i)
+}
+
+/// Calculates the time difference between notes `score[index1]` and `score[index2]`
+fn time_difference(score: &[ScoreNote], index1: usize, index2: usize) -> u32 {
     score[index2].time - score[index1].time
 }
 
+/// Finds matches in the score for new notes in the live performance
+///
+/// # Arguments
+///
+/// * score - The complete expected musical score with timestamps and pitches
+/// * live - The live performance recorded so far, with timestamps and pitches
+/// * prev_match_score_index - Index of the last note so far which has been matched
+///                            between the live performance and the expected score
+/// * new_live_index - Index of the first new note received for the live performance
+///                    since the previous round
+///
+/// # Return value
+///
+/// A 2-tuple of
+/// * newly found matches between the live performance and the expected score
+/// * ignored new input notes (as a list of live performance indices)
 fn find_new_matches(
     score: &[ScoreNote],
     live: &[ScoreNote],
@@ -35,19 +58,16 @@ fn find_new_matches(
     new_live_index: usize,
 ) -> (Vec<Match>, Vec<usize>) {
     let mut score_pointer = match prev_match_score_index {
+        Some(i) => i + 1, // continue in the score just after last previous match, or
         None => 0,        // start from beginning of score if nothing matched yet
-        Some(i) => i + 1, // continue in the score just after last previous match
     };
     let mut matches: Vec<Match> = vec![];
     let mut ignored: Vec<usize> = vec![];
     for (live_index, live_note) in live.iter().enumerate().skip(new_live_index) {
-        let matching_index = find_next_match_after(score, score_pointer, live_note.pitch);
+        let matching_index = find_next_match_starting_at(score, score_pointer, live_note.pitch);
         match matching_index {
             Some(score_index) => {
-                matches.push(Match {
-                    score_index,
-                    live_index,
-                });
+                matches.push(Match::new(score_index, live_index));
                 score_pointer = score_index + 1;
             }
             None => ignored.push(live_index),
@@ -56,18 +76,39 @@ fn find_new_matches(
     (matches, ignored)
 }
 
-fn get_stretch_factor(
-    elapsed_score: u32,
-    elapsed_live: u32,
-) -> f32 {
+/// Calculates the stretch factor from elapsed time in the score and the live performance
+///
+/// # Arguments
+///
+/// * elapsed_score - Time elapsed between two notes in the expected score
+/// * elapsed_live - Time elapsed between the same notes in the live performance
+///
+/// # Return value
+///
+/// The ratio between `elapsed_live` and `elapsed_score`
+fn get_stretch_factor(elapsed_score: u32, elapsed_live: u32) -> f32 {
     (elapsed_live as f32) / (elapsed_score as f32)
 }
 
 /// Returns the score time in milliseconds corresponding to the latest live note
 /// (whether matched or unmatched)
 ///
-/// Corrects the elapsed time since the last match using the calculated stretch factor,
-/// and adds that to the score time of the last match.
+/// This can be the exact time index of the latest performed note in the expected score,
+/// in case a match was found for that performed note. If no match was found (i.e. it's
+/// a wrong or an extra note), an estimate based on the last previous match and the
+/// current time stretch factor is returned.
+///
+/// # Arguments
+///
+/// * score - The complete expected musical score with timestamps and pitches
+/// * live - The live performance recorded so far, with timestamps and pitches
+/// * prev_match - The index, in the score and in the live performance, for a matching
+///                note.
+/// * stretch_factor - The time stretch factor to use
+///
+/// # Return value
+///
+/// The estimated current time in the expected score in milliseconds.
 fn get_score_time(
     score: &[ScoreNote],
     live: &[ScoreNote],
@@ -91,6 +132,7 @@ fn get_score_time(
 ///
 /// # Example
 ///
+/// ```text
 /// |                        111
 /// |        time: 0123456789012
 /// |                  v------------ prev_match_score_index == 1 (last matched note)
@@ -101,6 +143,7 @@ fn get_score_time(
 /// |                  ^   ^   ^----
 /// |                  |   `-------- new_live_index == 2 (first newly received note)
 /// |                  `------------ prev_match_live_index == 1 (last matched node)
+/// ```
 ///
 /// This would return
 /// * 8 as the timestamp of the score since that's when the last live note (F) occurs in
@@ -125,11 +168,10 @@ fn get_score_time(
 ///
 /// # Return value
 ///
-/// A 3-tuple of
+/// A 4-tuple of
 /// * the timestamp of the score at the last new input note
 /// * the time stretch factor at the last new matching input note
-/// * the index of the last matched note in the score
-/// * the index of the last matched note in the live performance
+/// * for all matched notes, the index in the score and in the live performance
 /// * ignored new input notes as a list of live performance indices
 pub fn follow_score(
     score: &[ScoreNote],
@@ -154,10 +196,8 @@ pub fn follow_score(
     let last_two = matches.rev().take(2).collect::<Vec<&Match>>();
     let stretch_factor = match last_two[..] {
         [last, second_last] => {
-            let elapsed_score =
-                time_difference(score, second_last.score_index, last.score_index);
-            let elapsed_live =
-                time_difference(live, second_last.live_index, last.live_index);
+            let elapsed_score = time_difference(score, second_last.score_index, last.score_index);
+            let elapsed_live = time_difference(live, second_last.live_index, last.live_index);
             get_stretch_factor(elapsed_score, elapsed_live)
         }
         _ => prev_stretch_factor,
@@ -189,13 +229,7 @@ mod tests {
             follow_score(&score, &live, None, 0, 1.0);
         assert_eq!(time, 1000);
         assert_approx_eq!(stretch_factor, 1.0);
-        assert_eq!(
-            new_matches,
-            [Match {
-                score_index: 0,
-                live_index: 0
-            }]
-        );
+        assert_eq!(new_matches, [Match::new(0, 0)]);
         assert!(ignored.is_empty());
     }
 
@@ -206,104 +240,48 @@ mod tests {
             follow_score(&TEST_SCORE, &live, None, 0, 1.0);
         assert_eq!(time, 1000);
         assert_approx_eq!(stretch_factor, 1.0);
-        assert_eq!(
-            new_matches,
-            [Match {
-                score_index: 0,
-                live_index: 0
-            }]
-        );
+        assert_eq!(new_matches, [Match::new(0, 0)]);
         assert!(ignored.is_empty());
     }
 
     #[test]
     fn match_second() {
         let live = notes![(5, 60), (55, 62)];
-        let (time, stretch_factor, new_matches, ignored) = follow_score(
-            &TEST_SCORE,
-            &live,
-            Some(Match {
-                score_index: 0,
-                live_index: 0,
-            }),
-            1,
-            1.0,
-        );
+        let (time, stretch_factor, new_matches, ignored) =
+            follow_score(&TEST_SCORE, &live, Some(Match::new(0, 0)), 1, 1.0);
         assert_eq!(time, 1100);
         assert_approx_eq!(stretch_factor, 0.5);
-        assert_eq!(
-            new_matches,
-            [Match {
-                score_index: 1,
-                live_index: 1,
-            }]
-        );
+        assert_eq!(new_matches, [Match::new(1, 1)]);
         assert!(ignored.is_empty());
     }
 
     #[test]
     fn skip_extra_note() {
         let live = notes![(5, 60), (25, 61), (55, 62)];
-        let (time, stretch_factor, new_matches, ignored) = follow_score(
-            &TEST_SCORE,
-            &live,
-            Some(Match {
-                score_index: 0,
-                live_index: 0,
-            }),
-            1,
-            1.0,
-        );
+        let (time, stretch_factor, new_matches, ignored) =
+            follow_score(&TEST_SCORE, &live, Some(Match::new(0, 0)), 1, 1.0);
         assert_eq!(time, 1100);
         assert_approx_eq!(stretch_factor, 0.5);
-        assert_eq!(
-            new_matches,
-            [Match {
-                score_index: 1,
-                live_index: 2,
-            }]
-        );
+        assert_eq!(new_matches, [Match::new(1, 2)]);
         assert_eq!(ignored, vec![1]);
     }
 
     #[test]
     fn skip_missing_note() {
         let live = notes![(5, 60), (55, 64)];
-        let (time, stretch_factor, new_matches, ignored) = follow_score(
-            &TEST_SCORE,
-            &live,
-            Some(Match {
-                score_index: 0,
-                live_index: 0,
-            }),
-            1,
-            1.0,
-        );
+        let (time, stretch_factor, new_matches, ignored) =
+            follow_score(&TEST_SCORE, &live, Some(Match::new(0, 0)), 1, 1.0);
         assert_eq!(time, 1200);
         assert_approx_eq!(stretch_factor, 0.25);
-        assert_eq!(
-            new_matches,
-            [Match {
-                score_index: 2,
-                live_index: 1,
-            }]
-        );
+        assert_eq!(new_matches, [Match::new(2, 1)]);
         assert!(ignored.is_empty());
     }
 
     #[test]
     fn only_wrong_notes() {
         let live = notes![(5, 60), (55, 63), (105, 66)];
-        let (time, stretch_factor, new_matches, ignored) = follow_score(
-            &TEST_SCORE,
-            &live,
-            Some(Match {
-                score_index: 0,
-                live_index: 0,
-            }),
-            1,
-            1.0,
-        );
+        let (time, stretch_factor, new_matches, ignored) =
+            follow_score(&TEST_SCORE, &live, Some(Match::new(0, 0)), 1, 1.0);
         assert_eq!(time, 1100);
         assert_approx_eq!(stretch_factor, 1.0);
         assert!(new_matches.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,21 +129,21 @@ fn get_score_time(
 /// * the index of the last matched note in the live performance
 /// * ignored new input notes as a list of live performance indices
 pub fn follow_score(
-    score: Vec<ScoreNote>,
-    live: Vec<ScoreNote>,
+    score: &[ScoreNote],
+    live: &[ScoreNote],
     prev_match_score_index: Option<usize>,
     prev_match_live_index: Option<usize>,
     new_live_index: usize,
     prev_stretch_factor: f32,
 ) -> (u32, f32, Option<usize>, Option<usize>, Vec<usize>) {
     let (next_match_score_index, next_match_live_index, ignored) =
-        find_newest_match(&score, &live, prev_match_score_index, new_live_index);
-    let elapsed_score = time_difference(&score, prev_match_score_index, next_match_score_index);
-    let elapsed_live = time_difference(&live, prev_match_live_index, next_match_live_index);
+        find_newest_match(score, live, prev_match_score_index, new_live_index);
+    let elapsed_score = time_difference(score, prev_match_score_index, next_match_score_index);
+    let elapsed_live = time_difference(live, prev_match_live_index, next_match_live_index);
     let stretch_factor = get_stretch_factor(elapsed_score, elapsed_live, prev_stretch_factor);
     let score_time = get_score_time(
-        &score,
-        &live,
+        score,
+        live,
         prev_match_score_index,
         prev_match_live_index,
         stretch_factor,
@@ -178,7 +178,7 @@ mod tests {
         let score = [note!(1000, 60)];
         let live = [note!(5, 60)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
-            follow_score(score.to_vec(), live.to_vec(), None, None, 0, 1.0);
+            follow_score(&score, &live, None, None, 0, 1.0);
         assert_eq!(time, 1000);
         assert_approx_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
@@ -190,7 +190,7 @@ mod tests {
     fn match_first() {
         let live = [note!(5, 60)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
-            follow_score(TEST_SCORE.to_vec(), live.to_vec(), None, None, 0, 1.0);
+            follow_score(&TEST_SCORE, &live, None, None, 0, 1.0);
         assert_eq!(time, 1000);
         assert_approx_eq!(stretch_factor, 1.0);
         assert_eq!(last_match_score, Some(0));
@@ -202,7 +202,7 @@ mod tests {
     fn match_second() {
         let live = [note!(5, 60), note!(55, 62)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
-            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+            follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
         assert_approx_eq!(stretch_factor, 0.5);
         assert_eq!(last_match_score, Some(1));
@@ -214,7 +214,7 @@ mod tests {
     fn skip_extra_note() {
         let live = [note!(5, 60), note!(25, 61), note!(55, 62)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
-            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+            follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1100);
         assert_approx_eq!(stretch_factor, 0.5);
         assert_eq!(last_match_score, Some(1));
@@ -226,7 +226,7 @@ mod tests {
     fn skip_missing_note() {
         let live = [note!(5, 60), note!(55, 64)];
         let (time, stretch_factor, last_match_score, last_match_live, ignored) =
-            follow_score(TEST_SCORE.to_vec(), live.to_vec(), Some(0), Some(0), 1, 1.0);
+            follow_score(&TEST_SCORE, &live, Some(0), Some(0), 1, 1.0);
         assert_eq!(time, 1200);
         assert_approx_eq!(stretch_factor, 0.25);
         assert_eq!(last_match_score, Some(2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,16 @@ pub struct ScoreNote {
     pitch: u8,
 }
 
+fn find_next_match_after(score: &Vec<ScoreNote>, score_index: usize, pitch: u8) -> Option<usize> {
+    let matching_index = score[score_index..]
+        .iter()
+        .position(|score_note| score_note.pitch == pitch);
+    match matching_index {
+        Some(i) => Some(score_index + i),
+        None => None,
+    }
+}
+
 /// Matches incoming notes with next notes in the score.
 /// This is a super naïve algorithm which
 /// * supports only monophony (order of events matters),
@@ -69,15 +79,12 @@ pub fn follow_score(
     let mut ignored: Vec<usize> = vec![];
     for live_index in new_live_index..live.len() {
         let live_note = live[live_index];
-        let matching_index = score[score_index..]
-            .iter()
-            .position(|score_note| score_note.pitch == live_note.pitch);
+        let matching_index = find_next_match_after(&score, score_index, live_note.pitch);
         match matching_index {
             Some(i) => {
                 next_match_live_index = Some(live_index);
-                score_index += i;
-                next_match_score_index = Some(score_index);
-                score_index += 1;
+                next_match_score_index = Some(i);
+                score_index = i + 1;
             }
             None => ignored.push(live_index),
         };

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::all)]
+
+/// A note with a given pitch at a given timestamp in a score or in a live performance
+#[derive(Clone, Copy)]
+pub struct ScoreNote {
+    pub time: u32,
+    pub pitch: u8,
+}


### PR DESCRIPTION
  - [x] inputs:
    - [x] complete reference score (ms+pitch)
    - [x] complete live input so far (ms+pitch)
    - [x] position of last matching previous input note in the score
    - [x] position of last matching previous input note in the live input
    - [x] position of first new note in the live input
    - [x] time stretch factor at matching note
  - [x] outputs:
    - [x] reference time index at last new input note (ms)
    - [x] time stretch factor at last new matching note
    - [x] list of ignored new input notes (ms+pitch)
  - [x] support only monophony (order of events matters)
  - [x] ignore unexpected (wrong/extra) notes
  - [x] keep waiting for next correct note
- [x] unit tests for `selim-0.1.0`
